### PR TITLE
Team members are an unordered set of users instead of a list

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -164,7 +164,7 @@ func resourceOpsGenieTeamUpdate(d *schema.ResourceData, meta interface{}) error 
 		Description: description,
 	}
 
-	if len(d.Get("member").([]interface{})) > 0 && !d.Get("ignore_members").(bool) {
+	if d.Get("member").(*schema.Set).Len() > 0 && !d.Get("ignore_members").(bool) {
 		updateRequest.Members = expandOpsGenieTeamMembers(d)
 	}
 
@@ -210,14 +210,14 @@ func flattenOpsGenieTeamMembers(input []team.Member) []map[string]interface{} {
 }
 
 func expandOpsGenieTeamMembers(d *schema.ResourceData) []team.Member {
-	input := d.Get("member").([]interface{})
-	members := make([]team.Member, 0, len(input))
+	input := d.Get("member").(*schema.Set)
+	members := make([]team.Member, 0, input.Len())
 
 	if input == nil {
 		return members
 	}
 
-	for _, v := range input {
+	for _, v := range input.List() {
 		config := v.(map[string]interface{})
 
 		userId := config["id"].(string)


### PR DESCRIPTION
Members of a team are not sortable and there orders should not matter.

Fix #288