### PR TITLE
Fix crash when creating new teams

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -78,7 +78,7 @@ func resourceOpsGenieTeamCreate(d *schema.ResourceData, meta interface{}) error 
 		Description: description,
 	}
 
-	if len(d.Get("member").([]interface{})) > 0 && !d.Get("ignore_members").(bool) {
+	if d.Get("member").(*schema.Set).Len() > 0 && !d.Get("ignore_members").(bool) {
 		createRequest.Members = expandOpsGenieTeamMembers(d)
 	}
 


### PR DESCRIPTION
This is a follow-up of #298, which also broke the creation of new teams.

Co-authored-by: Muhammad Saiful Islam <muhammad@saiful.web.id>